### PR TITLE
1.3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,11 @@ requirements:
   host:
     - python
     - pip
-    - numpy
     - setuptools
     - wheel
+    - numpy   1.19  # [py<310]
+    - numpy   1.21  # [py==310]
+    - numpy   1.23  # [py>=311]
     - msinttypes       # [win and py<35]
     - _openmp_mutex    # [linux and aarch64]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 780b693d0555b857d7aab31e35d4293bf4ebdb9dec7a45ba4bb23b4400f626dc
 
 build:
-  number: 1002
+  number: 0
   script:
     - export USE_OMP=1  # [linux]
     - export USE_OMP=0  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,11 +28,11 @@ requirements:
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]
     - msinttypes       # [win and py<35]
-    - _openmp_mutex    # [linux and aarch64]
+    - _openmp_mutex    # [linux]
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - _openmp_mutex    # [linux and aarch64]
+    - _openmp_mutex    # [linux]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<37]
   script:
     - export USE_OMP=1  # [linux]
     - export USE_OMP=0  # [osx]
@@ -27,7 +28,6 @@ requirements:
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]
-    - msinttypes       # [win and py<35]
     - _openmp_mutex    # [linux]
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,17 @@ test:
     - pip check
 
 about:
-  home: https://pypi.python.org/pypi/pykdtree
-  license: LGPL-3.0
+  home: https://github.com/storpipfugl/pykdtree
+  dev_url: https://github.com/storpipfugl/pykdtree
+  doc_url: https://github.com/storpipfugl/pykdtree/blob/master/README.rst
+  license: LGPL-3.0-or-later
   license_file: LICENSE.txt
+  license_family: LGPL
   summary: 'Fast kd-tree implementation with OpenMP-enabled queries'
+  description: |
+    pykdtree is a kd-tree implementation for fast nearest neighbour search in Python. 
+    The aim is to be the fastest implementation around for common use cases 
+    (low dimensions and low number of neighbours) for both tree construction and queries.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - python
     - pip
     - numpy
+    - setuptools
+    - wheel
     - msinttypes       # [win and py<35]
     - _openmp_mutex    # [linux and aarch64]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,12 @@ requirements:
     - _openmp_mutex    # [linux and aarch64]
 
 test:
+  requires:
+    - pip
   imports:
     - pykdtree
+  commands:
+    - pip check
 
 about:
   home: https://pypi.python.org/pypi/pykdtree

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.4" %}
+{% set version = "1.3.6" %}
 
 package:
   name: pykdtree
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pykdtree/pykdtree-{{ version }}.tar.gz
-  sha256: bebe5c608129f2997e88510c00010b9a78581b394924c0e3ecd131d52415165d
+  sha256: 780b693d0555b857d7aab31e35d4293bf4ebdb9dec7a45ba4bb23b4400f626dc
 
 build:
   number: 1002


### PR DESCRIPTION
# pykdtree 1.3.6

upstream: https://github.com/storpipfugl/pykdtree/tree/v1.3.6
release notes: https://github.com/storpipfugl/pykdtree/releases/tag/v1.3.6
license: https://github.com/storpipfugl/pykdtree/blob/v1.3.6/LICENSE.txt
`setup.py`: https://github.com/storpipfugl/pykdtree/blob/v1.3.6/setup.py#L105

## Changes
- Bump version and SHA
- Reset build number to 0
- Add `setuptools` and `wheel`
- Update about section
- Add `pip check`

## Notes
- This adds python 3.11 support